### PR TITLE
[debug] 补充漏掉的配置删除

### DIFF
--- a/wtpy/monitor/WatchDog.py
+++ b/wtpy/monitor/WatchDog.py
@@ -429,7 +429,7 @@ class WatchDog:
             return
 
         self.__apps__.pop(appid)
-
+        self.__app_conf__.pop(appid)
         cur = self.__db_conn__.cursor()
         cur.execute("DELETE FROM schedules WHERE appid='%s';" % (appid))
         self.__db_conn__.commit()


### PR DESCRIPTION
在删除app后，由于没有删除对应的配置要求，在刷新任务后，会提示keyError问题
#45 