### PR TITLE
[mod] hft引擎on_getbars参数不一致

### DIFF
--- a/wtpy/HftContext.py
+++ b/wtpy/HftContext.py
@@ -70,7 +70,7 @@ class HftContext:
         for newTick in newTicks:
             ticks.append(newTick)
 
-    def on_getbars(self, stdCode:str, period:str, newBars:list, isLast:bool):
+    def on_getbars(self, stdCode:str, period:str, newBars:list):
         key = "%s#%s" % (stdCode, period)
 
         bars = self.__bar_cache__[key]


### PR DESCRIPTION
在on_stra_get_barL162行中调用ctx.on_getbars(bytes.decode(stdCode), period, bars)，由于hft与cta 等引擎在on_getbars中的参数不一致，因此会报如下错误
```
Traceback (most recent call last):
  File "_ctypes/callbacks.c", line 232, in 'calling callback function'
  File "D:\ProgramFiles\anaconda3\envs\quant\lib\site-packages\wtpy\wrapper\WtWrapper.py", line 162, in 
on_stra_get_bar
    ctx.on_getbars(bytes.decode(stdCode), period, bars)
TypeError: on_getbars() missing 1 required positional argument: 'isLast'
```