### PR TITLE
[mod] 修复次主力递延一位时出现的越界错误

### DIFF
--- a/wtpy/apps/WtHotPicker.py
+++ b/wtpy/apps/WtHotPicker.py
@@ -708,7 +708,7 @@ class WtHotPicker:
                                     break
 
                         #如果主力合约月份大于等于次主力合约，则次主力递延一位
-                        if hot.month >= sec.month:
+                        if hot.month >= sec.month and len(ay)>=3:
                             sec = ay[-3]
                         
                         seconds[pid] = sec.code


### PR DESCRIPTION
如题，在递延前检查一次数组长度，避免出现越界错误