### PR TITLE
[mod] 增加一个增量回测的接口

### DIFF
--- a/wtpy/WtBtEngine.py
+++ b/wtpy/WtBtEngine.py
@@ -193,6 +193,12 @@ class WtBtEngine:
         if storage is not None:
             self.__config__["replayer"]["store"] = storage
 
+    def configIncrementalBt(self, incrementBtBase:str):
+        '''
+        设置增量
+        '''
+        self.__config__["env"]["incremental_backtest_base"] = incrementBtBase
+        
     def registerCustomRule(self, ruleTag:str, filename:str):
         '''
         注册自定义连续合约规则


### PR DESCRIPTION
通过增加配置:incremental_backtest_base
```yaml
env:
    mocker: cta                     # 回测引擎，cta/hft/sel/uft/exec
    slippage: 1
    incremental_backtest_base: outputs_bt/dt_if_0110
```
或者调用函数engine.configIncrementalBt
```python
    incremental_backtest_base = "outputs_bt/pydt_IF_base"
    engine.configIncrementalBt(incremental_backtest_base)
```
即可实现增量回测，但要注意基础回测的结束时间，和增量回测的起始时间是否合理