### PR TITLE
[fix]修复了ExtExecuter的编码导致无法回调的问题

### DIFF
--- a/wtpy/WtEngine.py
+++ b/wtpy/WtEngine.py
@@ -104,9 +104,9 @@ class WtEngine:
         return self.__ext_parsers__[id]
 
     def get_extended_executer(self, id:str)->BaseExtExecuter:
-        if id not in self.__ext_executers__:
+        if id.decode() not in self.__ext_executers__:
             return None
-        return self.__ext_executers__[id]
+        return self.__ext_executers__[id.decode()]
 
     def push_quote_from_extended_parser(self, id:str, newTick, uProcFlag:int):
         '''

--- a/wtpy/wrapper/WtWrapper.py
+++ b/wtpy/wrapper/WtWrapper.py
@@ -365,7 +365,7 @@ class WtWrapper:
         if executer is None:
             return
 
-        executer.set_position(stdCode, targetPos)
+        executer.set_position(stdCode.decode(), targetPos)
 
     def on_load_fnl_his_bars(self, stdCode:str, period:str):
         engine = self._engine


### PR DESCRIPTION
经测试多个环境测试（windows/Ubuntu）都无法回调到demo/test_extmodule下自定义的"class MyExecuter(BaseExtExecuter)"，经过调试排查，修复了对应的地方。