### PR TITLE
[fix]修复BtSnooper获取K线时无法解析realBar.bartime的问题

### DIFF
--- a/wtpy/monitor/WtBtSnooper.py
+++ b/wtpy/monitor/WtBtSnooper.py
@@ -844,15 +844,15 @@ class WtBtSnooper:
         isDay = period[0]=='d'
 
         bars = list()
-        for realBar in barList:
+        for i in range(len(barList)):
+            realBar = barList[i]
             bar = dict()
-            bar["bartime"] = int(realBar.date if isDay  else 199000000000 + realBar.bartime)
-            bar["open"] = realBar.open
-            bar["high"] = realBar.high
-            bar["low"] = realBar.low
-            bar["close"] = realBar.close
-            bar["volume"] = realBar.volume
-            bar["turnover"] = realBar.money
-            bars.append(bar)
+            bar["bartime"] = int(realBar['date'] if isDay  else 199000000000 + realBar['time'])
+            bar["open"] = realBar['open']
+            bar["high"] = realBar['high']
+            bar["low"] = realBar['low']
+            bar["close"] = realBar['close']
+            bar["volume"] = realBar['volume']
+            bar["turnover"] = realBar['turnover']
 
         return code, bars, index, marks


### PR DESCRIPTION
WtDataDefds.NpTypeBar中field与此处realBar的field不同，现已更新