### PR TITLE
修复WtBtAnalyst中手续费的计算与WtHotPicker对郑商所和上期所的兼容

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ fastapi
 uvicorn
 itsdangerous
 websockets>=9.1
+xlrd

--- a/wtpy/apps/WtHotPicker.py
+++ b/wtpy/apps/WtHotPicker.py
@@ -183,7 +183,7 @@ class WtCacheMonExchg(WtCacheMon):
         '''
 
         dtStr = curDT.strftime('%Y%m%d')
-        content = httpGet("http://www.shfe.com.cn/data/dailydata/kx/kx%s.dat" % (dtStr))
+        content = httpGet("http://tsite.shfe.com.cn/data/dailydata/kx/kx%s.dat" % (dtStr))
         if len(content) == 0:
             return None
         


### PR DESCRIPTION
## WtBtAnalyst的手续费计算
以demos/cta_arbitrage_bt/runBT.py为例：
1. 根据代码逻辑，`adjust_profit` = `profit` - `transaction_fee`；然而生成的xlsx中，`调整净利润`比`净利润`还高，如下图红框
<img width="280" alt="WtBtAnalyst" src="https://github.com/user-attachments/assets/3475b3d9-9b05-4425-bd9b-a83f7f35fc74">

2. 上图蓝框的“已付手续费”，与/outputs_bt/t1_rb_i/trades.csv的`fee`列求和的值(即2151.64)不同

在d655afa中根据上版本代码逻辑修复了此问题

## WtHotPicker的兼容
运行demos/test_hotpicker/testHots.py时，发现无法成功获取郑商所和上期所的每日结算数据
1. 郑商所的目标地址`http://www.czce.com.cn/cn/DFSStaticFiles/Future/%s/%s/FutureDataDaily.htm`以js生成cookie的方式做了反爬。d706c87的目标地址改成`http://www.czce.com.cn/cn/DFSStaticFiles/Future/%s/%s/FutureDataDaily.xls`，使用pandas读取(依赖xlrd)
2. 上期所的目标地址目标地址直接404了，在浏览器上也打不开。22186a8修改目标地址到老版网站`http://tsite.shfe.com.cn/data/dailydata/kx/kx%s.dat`

